### PR TITLE
Remove redundant assignment of the baseUrl in ReviewApplicationTests

### DIFF
--- a/udacity-jwdnd-c1-l5-final-review-solution-master/src/test/java/com/udacity/jwdnd/c1/review/ReviewApplicationTests.java
+++ b/udacity-jwdnd-c1-l5-final-review-solution-master/src/test/java/com/udacity/jwdnd/c1/review/ReviewApplicationTests.java
@@ -38,7 +38,7 @@ class ReviewApplicationTests {
 
 	@BeforeEach
 	public void beforeEach() {
-		baseURL = baseURL = "http://localhost:" + port;
+		baseURL = "http://localhost:" + port;
 	}
 
 	@Test


### PR DESCRIPTION
Remove the redundant assignment of the baseUrl in line 41 in the ReviewApplicationTests. This was mentioned in issue #6 by DemonDaddy22.